### PR TITLE
fix imported function calls

### DIFF
--- a/src/js/diagram.toolbar.js
+++ b/src/js/diagram.toolbar.js
@@ -231,8 +231,8 @@ export const diagramToolbar = {
     const margin = 200;
     const width = svg.width.baseVal.value + margin;
     const height = svg.height.baseVal.value + margin;
-    const pdf = new jsPDF.default("l", "pt", [width, height]);
-    svg2pdf.default(svg, pdf, {
+    const pdf = new jsPDF("l", "pt", [width, height]);
+    svg2pdf(svg, pdf, {
       xOffset: margin / 2,
       yOffset: margin / 2,
       scale: 1,


### PR DESCRIPTION
Switched to npm require instead of import. These old libraries don't need to explicitly call default now.